### PR TITLE
Add remove item modal and update script

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,26 @@
     </div>
   </div>
 
+  <!-- Remove Item Modal -->
+  <div id="removeItemModal" class="edit-item-modal" role="dialog" aria-label="Remover item" aria-hidden="true">
+    <div class="edit-overlay"></div>
+    <div class="edit-modal">
+      <div class="edit-header">
+        <h3>Remover Item</h3>
+        <button class="edit-close" aria-label="Fechar modal">×</button>
+      </div>
+
+      <div class="edit-content">
+        <p>Deseja remover este item?</p>
+      </div>
+
+      <div class="edit-actions">
+        <button type="button" class="edit-btn secondary" id="removeCancel">Cancelar</button>
+        <button type="button" class="edit-btn primary" id="removeConfirm">Remover</button>
+      </div>
+    </div>
+  </div>
+
   <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated remove item modal to HTML before loading script.js
- use `showRemoveModal` with `getElement('removeItemModal')` and wire up removal buttons
- log missing remove modal elements during initialization for easier debugging

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

